### PR TITLE
Dd/claude metronome

### DIFF
--- a/src/components/timed-pitches/TimedPitchesPlayer.tsx
+++ b/src/components/timed-pitches/TimedPitchesPlayer.tsx
@@ -35,13 +35,9 @@ function TimedPitchesPlayerRaw({ config, onEnd }: TimedPitchesPlayerProps) {
           config.numberOfCycles * config.beatsPerNote * notePool.current.length,
         onEnd,
       },
-      onBeatStart: ({ beatNumber }) => {
-        console.log("Beat number:", beatNumber);
-      },
       beatInterval: {
         count: config.beatsPerNote,
         onBeatInterval: ({ currentInterval }) => {
-          console.log(currentInterval);
           const currentNote =
             notePool.current[currentInterval % notePool.current.length];
 

--- a/src/components/timed-pitches/TimedPitchesPlayer.tsx
+++ b/src/components/timed-pitches/TimedPitchesPlayer.tsx
@@ -1,6 +1,6 @@
 import "./TimedPitchesPlayer.css";
 
-import { Button, Flex, Title } from "@mantine/core";
+import { Flex, Title } from "@mantine/core";
 import { memo, useEffect, useRef, useState } from "react";
 
 import { ExerciseTimedPitchesConfig } from "@/core/practice-session";
@@ -29,39 +29,16 @@ function TimedPitchesPlayerRaw({ config, onEnd }: TimedPitchesPlayerProps) {
       tempo: Math.round(config.tempo),
       beatsPerBar: 4,
       volume: 50,
-      // see if we can push more down into the metronome
-      // events:
-      //  - one for when a note should change - what would the generic term be?
-      //  - one for when it "repeats" based on the config?
-      //  - onEnd: inform the metronome of total beats and it can fire an event
-      //            and clean itself up after that many beats
-      // Basically push down all of these decisions to the metronome so it can alert
-      // consumers when they happen
-      // Just need to think of good names for these things
-      // But then the components become much simpler
-      onBeatStart: ({ totalBeats }) => {
-        // Check if the current beat is the start of a note interval
-        if ((totalBeats - 1) % config.beatsPerNote === 0) {
-          // Calculate the note index based on the total beats
-          const noteIndex =
-            Math.floor((totalBeats - 1) / config.beatsPerNote) %
-            notePool.current.length;
-
-          // Determine the current cycle
-          const cycleIndex = Math.floor(
-            (totalBeats - 1) / (config.beatsPerNote * notePool.current.length),
-          );
-
-          // End the exercise if the cycle limit is reached
-          if (cycleIndex >= config.numberOfCycles) {
-            onEnd();
-            return;
-          }
-
-          // Get the current note from the note pool
-          const currentNote = notePool.current[noteIndex];
-
-          // Update the state with the current note
+      maxBeats: {
+        count:
+          config.numberOfCycles * config.beatsPerNote * notePool.current.length,
+        onEnd: onEnd,
+      },
+      beatInterval: {
+        count: config.beatsPerNote,
+        onBeatInterval: ({ currentInterval }) => {
+          const currentNote =
+            notePool.current[currentInterval % notePool.current.length];
           setNote(currentNote);
 
           // Play the note using the pitch generator
@@ -70,7 +47,7 @@ function TimedPitchesPlayerRaw({ config, onEnd }: TimedPitchesPlayerProps) {
             duration: 750, // Adjust duration as needed
             volume: 0.5, // Adjust volume as needed
           });
-        }
+        },
       },
     });
 

--- a/src/components/timed-pitches/TimedPitchesPlayer.tsx
+++ b/src/components/timed-pitches/TimedPitchesPlayer.tsx
@@ -5,7 +5,6 @@ import { memo, useEffect, useRef, useState } from "react";
 
 import { ExerciseTimedPitchesConfig } from "@/core/practice-session";
 import clsx from "clsx";
-// import { createMetronome } from "@/core/sound/metronome";
 import { createMetronome } from "@/core/sound/claude-metronome";
 import { createPitchGenerator } from "@/core/sound/pitch-generator";
 import { getNotePool } from "@/core/utils";
@@ -18,8 +17,6 @@ type TimedPitchesPlayerProps = {
 
 function TimedPitchesPlayerRaw({ config, onEnd }: TimedPitchesPlayerProps) {
   // default the screen to "empty" state
-  // we use the metronome to sync state changes and we want to initialize on the first beat
-  const metronomeRef = useRef<ReturnType<typeof createMetronome> | null>(null);
   const notePool = useRef(getNotePool(config.notePool));
   const [note, setNote] = useState("");
 
@@ -32,30 +29,27 @@ function TimedPitchesPlayerRaw({ config, onEnd }: TimedPitchesPlayerProps) {
       maxBeats: {
         count:
           config.numberOfCycles * config.beatsPerNote * notePool.current.length,
-        onEnd: onEnd,
+        onEnd,
       },
       beatInterval: {
         count: config.beatsPerNote,
         onBeatInterval: ({ currentInterval }) => {
           const currentNote =
             notePool.current[currentInterval % notePool.current.length];
-          setNote(currentNote);
 
-          // Play the note using the pitch generator
+          setNote(currentNote);
           pitchGenerator.play({
             frequency: noteFrequencies[currentNote],
-            duration: 750, // Adjust duration as needed
-            volume: 0.5, // Adjust volume as needed
+            duration: 750,
+            volume: 0.5,
           });
         },
       },
     });
 
-    metronomeRef.current = metronome;
     metronome.start();
 
     return () => {
-      metronomeRef.current = null;
       metronome.stop();
       pitchGenerator.dispose();
     };

--- a/src/core/sound/claude-metronome.ts
+++ b/src/core/sound/claude-metronome.ts
@@ -1,0 +1,234 @@
+type BeatEvent = {
+  beatNumber: number; // Current beat in the bar (1-based)
+  time: number; // Audio context time
+  totalBeats: number; // Total beats since metronome started
+};
+
+type MetronomeConfig = {
+  tempo: number;
+  beatsPerBar: number;
+  volume: number; // 0-100
+  onBeatStart?: (event: BeatEvent) => void;
+};
+
+type PlaybackState = "playing" | "stopped" | "paused";
+
+type MetronomeState = {
+  playbackState: PlaybackState;
+  currentBeat: number;
+  totalBeats: number;
+  nextNoteTime: number;
+  audioContext: AudioContext | null;
+  timerID: number | null;
+  lookaheadMs: number; // How far ahead to schedule audio (in milliseconds)
+};
+
+export function createMetronome(config: MetronomeConfig) {
+  const state: MetronomeState = {
+    playbackState: "stopped",
+    currentBeat: 0,
+    totalBeats: 0,
+    nextNoteTime: 0,
+    audioContext: null,
+    timerID: null,
+    lookaheadMs: 25.0, // 25ms lookahead
+  };
+
+  let tempo = config.tempo;
+  let beatsPerBar = config.beatsPerBar;
+  let volume = config.volume / 100; // Convert to 0-1 range
+  let onBeatStart = config.onBeatStart || ((event: BeatEvent) => {});
+
+  // Calculate beat length in seconds based on tempo (BPM)
+  const getBeatLength = () => 60.0 / tempo;
+
+  // Create and configure audio context if it doesn't exist
+  const initializeAudioContext = () => {
+    if (!state.audioContext) {
+      state.audioContext = new AudioContext();
+    }
+    return state.audioContext;
+  };
+
+  // Generate a click sound at the specified time
+  const scheduleNote = (time: number) => {
+    if (!state.audioContext) return;
+
+    // Create oscillator
+    const oscillator = state.audioContext.createOscillator();
+    const gainNode = state.audioContext.createGain();
+
+    // Configure oscillator
+    // Use different frequency for the first beat of the bar
+    oscillator.frequency.value =
+      state.currentBeat % beatsPerBar === 0 ? 1000 : 800;
+
+    // Configure volume
+    gainNode.gain.value = volume;
+
+    // Short duration click
+    gainNode.gain.setValueAtTime(volume, time);
+    gainNode.gain.exponentialRampToValueAtTime(0.001, time + 0.03);
+
+    // Connect nodes
+    oscillator.connect(gainNode);
+    gainNode.connect(state.audioContext.destination);
+
+    // Schedule and play
+    oscillator.start(time);
+    oscillator.stop(time + 0.03);
+
+    // Create a separate oscillator just for precise callback timing
+    // Calculate the actual beat number (1-based) to pass to the callback
+    const beatNumber = state.currentBeat + 1;
+
+    // Create a separate oscillator just for precise callback timing
+    const callbackTrigger = state.audioContext.createOscillator();
+
+    // Use minimal resources - inaudible frequency and no gain needed
+    callbackTrigger.frequency.value = 1;
+
+    // Set up the callback to fire exactly when the oscillator ends
+    callbackTrigger.onended = () => {
+      onBeatStart({
+        beatNumber,
+        time,
+        totalBeats: state.totalBeats,
+      });
+    };
+
+    // Schedule it to start and stop immediately at the exact time of the beat
+    callbackTrigger.start(time);
+    callbackTrigger.stop(time + 0.001); // Minimal duration to trigger onended
+  };
+
+  // Schedule notes ahead of time
+  const scheduler = () => {
+    if (!state.audioContext) return;
+
+    // Convert lookahead from ms to seconds for audio scheduling
+    const scheduleAheadTimeSec = state.lookaheadMs / 1000;
+
+    // Schedule notes until we're a little ahead
+    while (
+      state.nextNoteTime <
+      state.audioContext.currentTime + scheduleAheadTimeSec
+    ) {
+      scheduleNote(state.nextNoteTime);
+
+      // Advance beat and time
+      state.currentBeat = (state.currentBeat + 1) % beatsPerBar;
+      state.totalBeats += 1;
+      state.nextNoteTime += getBeatLength();
+    }
+
+    // Schedule next check
+    state.timerID = window.setTimeout(scheduler, state.lookaheadMs);
+  };
+
+  // Start the metronome
+  const start = () => {
+    if (state.playbackState === "playing") return;
+
+    const audioContext = initializeAudioContext();
+
+    if (state.playbackState === "stopped") {
+      // Not resuming, so reset the beat counter
+      state.currentBeat = 0;
+    }
+
+    state.playbackState = "playing";
+    state.nextNoteTime = audioContext.currentTime;
+
+    scheduler();
+  };
+
+  // Stop the metronome
+  const stop = () => {
+    if (state.playbackState === "stopped") return;
+
+    state.playbackState = "stopped";
+    state.currentBeat = 0; // Reset beat counter
+    state.totalBeats = 0; // Reset total beats counter
+
+    if (state.timerID !== null) {
+      window.clearTimeout(state.timerID);
+      state.timerID = null;
+    }
+  };
+
+  // Pause the metronome - maintains current beat position
+  const pause = () => {
+    if (state.playbackState !== "playing") return;
+
+    state.playbackState = "paused";
+
+    // Stop the scheduler
+    if (state.timerID !== null) {
+      window.clearTimeout(state.timerID);
+      state.timerID = null;
+    }
+  };
+
+  // Resume the metronome from paused state
+  const resume = () => {
+    if (state.playbackState !== "paused") return;
+
+    // Move to the next beat when resuming
+    state.currentBeat = (state.currentBeat + 1) % beatsPerBar;
+
+    // Use start to handle the resumed state
+    start();
+  };
+
+  // Update configuration
+  const updateConfig = (newConfig: Partial<MetronomeConfig>) => {
+    const wasPlaying = state.playbackState === "playing";
+
+    // Stop if playing
+    if (wasPlaying) {
+      stop();
+    }
+
+    // Update values
+    if (newConfig.tempo !== undefined) {
+      tempo = newConfig.tempo;
+    }
+
+    if (newConfig.beatsPerBar !== undefined) {
+      beatsPerBar = newConfig.beatsPerBar;
+    }
+
+    if (newConfig.volume !== undefined) {
+      volume = newConfig.volume / 100;
+    }
+
+    if (newConfig.onBeatStart !== undefined) {
+      onBeatStart = newConfig.onBeatStart || ((event: BeatEvent) => {});
+    }
+
+    // Restart if it was playing
+    if (wasPlaying) {
+      start();
+    }
+  };
+
+  // Get current state
+  const getState = () => ({
+    playbackState: state.playbackState,
+    tempo,
+    beatsPerBar,
+    volume: volume * 100,
+    currentBeat: state.currentBeat,
+    totalBeats: state.totalBeats,
+  });
+
+  return {
+    start,
+    stop,
+    pause,
+    resume,
+    updateConfig,
+    getState,
+  };
+}

--- a/src/core/sound/claude-metronome.ts
+++ b/src/core/sound/claude-metronome.ts
@@ -35,6 +35,8 @@ type MetronomeState = {
   lookaheadMs: number; // How far ahead to schedule audio (in milliseconds)
 };
 
+const noop = () => {};
+
 export function createMetronome(config: MetronomeConfig) {
   const state: MetronomeState = {
     playbackState: "stopped",
@@ -50,7 +52,7 @@ export function createMetronome(config: MetronomeConfig) {
   let tempo = config.tempo;
   let beatsPerBar = config.beatsPerBar;
   let volume = config.volume / 100; // Convert to 0-1 range
-  let onBeatStart = config.onBeatStart || ((event: BeatEvent) => {});
+  let onBeatStart = config.onBeatStart || noop;
   let maxBeatsConfig = config.maxBeats || null;
   let beatIntervalConfig = config.beatInterval || null;
 
@@ -268,7 +270,7 @@ export function createMetronome(config: MetronomeConfig) {
     }
 
     if (newConfig.onBeatStart !== undefined) {
-      onBeatStart = newConfig.onBeatStart || ((event: BeatEvent) => {});
+      onBeatStart = newConfig.onBeatStart || noop;
     }
 
     if (newConfig.maxBeats !== undefined) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,12 +14,12 @@ const rootElement = document.getElementById("root")!;
 if (!rootElement.innerHTML) {
   const root = ReactDOM.createRoot(rootElement);
   root.render(
-    <StrictMode>
-      <QueryClientProvider client={queryClient}>
-        <MantineProvider>
-          <AppRouter />
-        </MantineProvider>
-      </QueryClientProvider>
-    </StrictMode>,
+    // <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <MantineProvider>
+        <AppRouter />
+      </MantineProvider>
+    </QueryClientProvider>,
+    // </StrictMode>,
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,12 +14,12 @@ const rootElement = document.getElementById("root")!;
 if (!rootElement.innerHTML) {
   const root = ReactDOM.createRoot(rootElement);
   root.render(
-    // <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <MantineProvider>
-        <AppRouter />
-      </MantineProvider>
-    </QueryClientProvider>,
-    // </StrictMode>,
+    <StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <MantineProvider>
+          <AppRouter />
+        </MantineProvider>
+      </QueryClientProvider>
+    </StrictMode>,
   );
 }


### PR DESCRIPTION
Creates a new metronome via Claude.
Eventually, I'd like to extract the metronome into its own package.
Some features

- pause - you can now pause/resume a playing metronome
- `onBeat` event which fired with every beat
- `maxBeats` allows you to say when the metronome should end and get a callback when it happens
- `beatInterval` allows you to define a callback that should fire every "x" number of beats

These features reduce the code needed in the exercise player itself.

I have a refactor for the player itself in mind, but that will come next. Interested to get this out there and test it.